### PR TITLE
Changed 'cp -p' to 'cp ${CP_OPTS}' to fix compilation on CSD3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 #
 include arch.make
 #
+ifeq (${CP_OPTS},)
+CP_OPTS="-p"
+endif
+#
 default: objsdir $(BUILD_TARGETS) examples_build
 	@if [ -z "$(BUILD_TARGETS)" ]; then echo "FoX is not configured!"; else touch .FoX; fi
 #

--- a/common/makefile
+++ b/common/makefile
@@ -25,7 +25,7 @@ include ../arch.make
 #FFLAGS=$(FFLAGS_PROFILE)
 #FFLAGS=$(FFLAGS_CHECK)
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "  ==> Creating $(LIBRARY) with $(OBJFILES)"
 	@$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)

--- a/configure
+++ b/configure
@@ -502,13 +502,14 @@ if ln -s conf$$.file conf$$ 2>/dev/null; then
   # ... but there are two gotchas:
   # 1) On MSYS, both `ln -s file dir' and `ln file dir' fail.
   # 2) DJGPP < 2.04 has no symlinks; `ln -s' creates a wrapper executable.
-  # In both cases, we have to default to `cp -p'.
+  # 3) On CSD3, `cp -p` fails so needed to change `cp -p` to `cp $CP_OPTS`. 
+  # In both cases, we have to default to `cp ${CP_OPTS}'. 
   ln -s conf$$.file conf$$.dir 2>/dev/null && test ! -f conf$$.exe ||
-    as_ln_s='cp -p'
+    as_ln_s='cp ${CP_OPTS}'
 elif ln conf$$.file conf$$ 2>/dev/null; then
   as_ln_s=ln
 else
-  as_ln_s='cp -p'
+  as_ln_s='cp ${CP_OPTS}'
 fi
 rm -f conf$$ conf$$.exe conf$$.dir/conf$$.file conf$$.file
 rmdir conf$$.dir 2>/dev/null
@@ -6750,13 +6751,13 @@ if ln -s conf$$.file conf$$ 2>/dev/null; then
   # ... but there are two gotchas:
   # 1) On MSYS, both `ln -s file dir' and `ln file dir' fail.
   # 2) DJGPP < 2.04 has no symlinks; `ln -s' creates a wrapper executable.
-  # In both cases, we have to default to `cp -p'.
+  # In both cases, we have to default to `cp ${CP_OPTS}'.
   ln -s conf$$.file conf$$.dir 2>/dev/null && test ! -f conf$$.exe ||
-    as_ln_s='cp -p'
+    as_ln_s='cp ${CP_OPTS}'
 elif ln conf$$.file conf$$ 2>/dev/null; then
   as_ln_s=ln
 else
-  as_ln_s='cp -p'
+  as_ln_s='cp ${CP_OPTS}'
 fi
 rm -f conf$$ conf$$.exe conf$$.dir/conf$$.file conf$$.file
 rmdir conf$$.dir 2>/dev/null

--- a/dom/makefile
+++ b/dom/makefile
@@ -28,7 +28,7 @@ m_dom_utils.f90: m_dom_utils.m4
 m_dom_dom.F90: $(M4FILES)
 	m4 -I ../m4 m_dom_dom.m4 > $@ 
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "  ==> Creating $(LIBRARY) with $(OBJFILES)"
 	$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)

--- a/fsys/makefile
+++ b/fsys/makefile
@@ -19,7 +19,7 @@ INCFLAGS=
 #
 include ../arch.make
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "  ==> Creating $(LIBRARY) with $(OBJFILES)"
 	@$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)

--- a/sax/makefile
+++ b/sax/makefile
@@ -11,7 +11,7 @@ INCFLAGS=$(MOD_PREFIX)../objs/finclude
 #
 include ../arch.make
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "  ==> Creating $(LIBRARY) with $(OBJFILES)"
 	@$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)

--- a/utils/makefile
+++ b/utils/makefile
@@ -9,7 +9,7 @@ INCFLAGS=$(MOD_PREFIX)../objs/finclude
 #
 include ../arch.make
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "  ==> Creating $(LIBRARY) with $(OBJFILES)"
 	@$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)

--- a/wcml/makefile
+++ b/wcml/makefile
@@ -14,7 +14,7 @@ INCFLAGS=$(MOD_PREFIX)../objs/finclude
 #
 include ../arch.make
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "  ==> Creating $(LIBRARY) with $(OBJFILES)"
 	@$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)

--- a/wkml/makefile
+++ b/wkml/makefile
@@ -17,7 +17,7 @@ include ../arch.make
 #FFLAGS=$(FFLAGS_PROFILE)
 #FFLAGS=$(FFLAGS_CHECK)
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "  ==> Updating $(LIBRARY) with $(OBJFILES)"
 	@$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)

--- a/wxml/makefile
+++ b/wxml/makefile
@@ -12,7 +12,7 @@ INCFLAGS=$(MOD_PREFIX)../objs/finclude
 #
 include ../arch.make
 #
-CP=cp -p
+CP=cp ${CP_OPTS}
 install: $(OBJFILES)
 	@echo "==> Creating $(LIBRARY) with $(OBJFILES)"
 	$(AR) $(ARFLAGS_EXTRA) cru $(LIBRARY) $(OBJFILES)


### PR DESCRIPTION
The CSD3 machine doesn't support the `-p` option of the `cp` command. This commit introduced a `${CP_OPTS}` variable that is set to `-p` in `src/fox/Makefile` if not set earlier. (For CSD3, it's set in `arch/Makefile.csd3_x86_64_gfortran_openmp`)